### PR TITLE
Fixed bootstrap carousel visible image resizing

### DIFF
--- a/config/theme.yml
+++ b/config/theme.yml
@@ -8,7 +8,7 @@ author:
 
 meta:
   compatibility:
-      from: 8.0.0
+      from: 8.1.0
       to: ~
 
   available_layouts:

--- a/modules/blockwishlist/views/templates/components/modals/add-to-wishlist.tpl
+++ b/modules/blockwishlist/views/templates/components/modals/add-to-wishlist.tpl
@@ -45,7 +45,7 @@
 
         <div class="modal-footer">
           <a @click="openNewWishlistModal" class="wishlist-add-to-new text-primary">
-            <i class="material-icons text-primary">add_circle_outline</i> {$newWishlistCTA}
+            <i class="material-icons text-primary" aria-hidden="true">add_circle_outline</i> {$newWishlistCTA}
           </a>
         </div>
       </div>

--- a/modules/blockwishlist/views/templates/hook/displayCustomerAccount.tpl
+++ b/modules/blockwishlist/views/templates/hook/displayCustomerAccount.tpl
@@ -19,7 +19,7 @@
 
 <a class="col-md-6 col-lg-4{if $urls.current_url === $url} active{/if}" id="wishlist-link" href="{$url}">
   <span class="link-item">
-    <i class="material-icons">favorite</i>
+    <i class="material-icons" aria-hidden="true">favorite</i>
     {$wishlistsTitlePage}
   </span>
 </a>

--- a/modules/productcomments/views/templates/hook/empty-product-comment.tpl
+++ b/modules/productcomments/views/templates/hook/empty-product-comment.tpl
@@ -6,7 +6,7 @@
 <div id="empty-product-comment" class="product-comment-list-item">
   {if $post_allowed}
     <button class="btn btn-primary btn-with-icon post-product-comment">
-      <i class="material-icons">&#xE3C9;</i>
+      <i class="material-icons" aria-hidden="true">&#xE3C9;</i>
       {l s='Be the first to write your review' d='Modules.Productcomments.Shop'}
     </button>
   {else}

--- a/modules/productcomments/views/templates/hook/product-comments-list.tpl
+++ b/modules/productcomments/views/templates/hook/product-comments-list.tpl
@@ -10,7 +10,7 @@
 <div class="row">
   <div class="col-md-12 col-sm-12" id="product-comments-list-header">
     <div class="comments-nb">
-      <i class="material-icons" data-icon="chat"></i>
+      <i class="material-icons" data-icon="chat" aria-hidden="true"></i>
       {l s='Comments' d='Modules.Productcomments.Shop'} ({$nb_comments})
     </div>
     {include file='module:productcomments/views/templates/hook/average-grade-stars.tpl' grade=$average_grade}
@@ -33,7 +33,7 @@
     <div id="product-comments-list-pagination"></div>
     {if $post_allowed && $nb_comments != 0}
       <button class="btn btn-primary btn-with-icon post-product-comment">
-        <i class="material-icons" data-icon="edit"></i>
+        <i class="material-icons" data-icon="edit" aria-hidden="true"></i>
         {l s='Write your review' d='Modules.Productcomments.Shop'}
       </button>
     {/if}

--- a/modules/ps_bestsellers/views/templates/hook/ps_bestsellers.tpl
+++ b/modules/ps_bestsellers/views/templates/hook/ps_bestsellers.tpl
@@ -8,7 +8,7 @@
         {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
         <div class="best-sellers-products-footer text-center">
             <a class="all-product-link btn btn-outline-primary" href="{$allBestSellers}">
-                {l s='All best sellers' d='Shop.Theme.Catalog'}<i class="material-icons rtl-flip">&#xE315;</i>
+                {l s='All best sellers' d='Shop.Theme.Catalog'}<i class="material-icons rtl-flip" aria-hidden="true">&#xE315;</i>
             </a>
         </div>
     </div>

--- a/modules/ps_brandlist/views/templates/_partials/brand_form.tpl
+++ b/modules/ps_brandlist/views/templates/_partials/brand_form.tpl
@@ -11,7 +11,7 @@
     aria-haspopup="true"
     aria-expanded="false">
     {l s='All brands' d='Shop.Theme.Catalog'}
-    <i class="material-icons float-end">arrow_drop_down</i>
+    <i class="material-icons float-end" aria-hidden="true">arrow_drop_down</i>
   </button>
   <div class="dropdown-menu dropdown-menu-start">
     {foreach from=$brands item=brand}

--- a/modules/ps_contactinfo/ps_contactinfo-rich.tpl
+++ b/modules/ps_contactinfo/ps_contactinfo-rich.tpl
@@ -5,34 +5,34 @@
 <div class="contact__details">
   <h2 class="contact__title">{l s='Store information' d='Shop.Theme.Global'}</h4>
   <div class="contact__item">
-    <i class="material-icons">&#xE55F;</i>
+    <i class="material-icons" aria-hidden="true">&#xE55F;</i>
     <div class="contact__info">{$contact_infos.address.formatted nofilter}</div>
   </div>
   {if $contact_infos.phone}
     <hr/>
     <div class="contact__item">
-      <i class="material-icons">&#xE0CD;</i>
+      <i class="material-icons" aria-hidden="true">&#xE0CD;</i>
       <div class="contact__info"><a href="tel:{$contact_infos.phone}">{$contact_infos.phone}</a></div>
     </div>
   {/if}
   {if $contact_infos.fax}
     <hr/>
     <div class="contact__item">
-      <i class="material-icons">&#xE0DF;</i>
+      <i class="material-icons" aria-hidden="true">&#xE0DF;</i>
       <div class="contact__info">{$contact_infos.fax}</div>
     </div>
   {/if}
   {if $contact_infos.email && $display_email}
     <hr/>
     <div class="contact__item">
-      <i class="material-icons">&#xE158;</i>
+      <i class="material-icons" aria-hidden="true">&#xE158;</i>
       <div class="contact__info contact__info--email">{mailto address=$contact_infos.email encode="javascript"}</div>
     </div>
   {/if}
   {if !empty($contact_infos.details)}
     <hr/>
     <div class="contact__item">
-      <i class="material-icons">&#xE88E;</i>
+      <i class="material-icons" aria-hidden="true">&#xE88E;</i>
       <div class="contact__info">{$contact_infos.details|nl2br nofilter}</div>
     </div>
   {/if}

--- a/modules/ps_contactinfo/ps_contactinfo.tpl
+++ b/modules/ps_contactinfo/ps_contactinfo.tpl
@@ -9,7 +9,7 @@
 
   <div class="footer__block__toggle d-md-none collapsed" data-bs-target="#contact-infos" data-bs-toggle="collapse" aria-expanded="false">
     <span class="footer__block__title">{l s='Store information' d='Shop.Theme.Global'}</span>
-    <i class="material-icons">arrow_drop_down</i>
+    <i class="material-icons" aria-hidden="true">arrow_drop_down</i>
   </div>
 
   <div id="contact-infos" class="footer__block__content footer__block__content-contact collapse">
@@ -20,21 +20,21 @@
 
     {if $contact_infos.phone}
       <div class="contact__phone">
-        <i class="material-icons">phone</i>
+        <i class="material-icons" aria-hidden="true">phone</i>
         <a href="tel:{$contact_infos.phone}">{$contact_infos.phone}</a>
       </div>
     {/if}
 
     {if $contact_infos.fax}
       <div class="contact__fax">
-        <i class="material-icons">fax</i>
+        <i class="material-icons" aria-hidden="true">fax</i>
         <a href="fax:{$contact_infos.fax}">{$contact_infos.fax}</a>
       </div>
     {/if}
 
     {if $contact_infos.email && $display_email}
       <div class="contact__email">
-        <i class="material-icons">mail</i>
+        <i class="material-icons" aria-hidden="true">mail</i>
         {mailto address=$contact_infos.email encode="javascript"}
       </div>
     {/if}

--- a/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
+++ b/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
@@ -12,7 +12,7 @@
 
   <div class="footer__block__toggle d-md-none collapsed" data-bs-target="#footer_account_list" data-bs-toggle="collapse" aria-expanded="false">
     <span class="footer__block__title">{l s='Your account' d='Shop.Theme.Customeraccount'}</span>
-    <i class="material-icons">arrow_drop_down</i>
+    <i class="material-icons" aria-hidden="true">arrow_drop_down</i>
   </div>
   <ul class="footer__block__content footer__block__content-list collapse" id="footer_account_list">
     {if $customer.is_logged}

--- a/modules/ps_customersignin/ps_customersignin.tpl
+++ b/modules/ps_customersignin/ps_customersignin.tpl
@@ -15,58 +15,58 @@
           data-bs-toggle="dropdown"
           aria-haspopup="true"
           aria-expanded="false">
-          <i class="material-icons header-block__icon">&#xE7FD;</i>
+          <i class="material-icons header-block__icon" aria-hidden="true">&#xE7FD;</i>
           <span class="header-block__title d-lg-inline d-none">{$customerName|truncate:22:"..":true}</span>
         </a>
 
         <div class="dropdown-menu dropdown-menu-start" aria-labelledby="userMenuButton">
           <a class="dropdown-item" href="{$urls.pages.my_account}">
-            <i class="material-icons me-2">&#xF02E;</i>
+            <i class="material-icons me-2" aria-hidden="true">&#xF02E;</i>
             {l s='Your account' d='Shop.Theme.Customeraccount'}
           </a>
           <div class="dropdown-divider"></div>
           <a href="{$urls.pages.identity}" title="{l s='Information' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">
-            <i class="material-icons me-2">&#xE853;</i>
+            <i class="material-icons me-2" aria-hidden="true">&#xE853;</i>
             {l s='Information' d='Shop.Theme.Customeraccount'}
           </a>
           {if $customer.addresses|count}
             <a href="{$urls.pages.addresses}" title="{l s='Addresses' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">
-              <i class="material-icons me-2">&#xE56A;</i>
+              <i class="material-icons me-2" aria-hidden="true">&#xE56A;</i>
               {l s='Addresses' d='Shop.Theme.Customeraccount'}
             </a>
           {else}
             <a href="{$urls.pages.address}" title="{l s='Add first address' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">
-              <i class="material-icons me-2">&#xE567;</i>
+              <i class="material-icons me-2" aria-hidden="true">&#xE567;</i>
               {l s='Add first address' d='Shop.Theme.Customeraccount'}
             </a>
           {/if}
           {if !$configuration.is_catalog}
             <a href="{$urls.pages.history}" title="{l s='Orders' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">
-              <i class="material-icons me-2">&#xE916;</i>
+              <i class="material-icons me-2" aria-hidden="true">&#xE916;</i>
               {l s='Orders' d='Shop.Theme.Customeraccount'}
             </a>
           {/if}
           {if !$configuration.is_catalog}
             <a href="{$urls.pages.order_slip}" title="{l s='Credit slips' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">
-              <i class="material-icons me-2">&#xE8B0;</i>
+              <i class="material-icons me-2" aria-hidden="true">&#xE8B0;</i>
               {l s='Credit slips' d='Shop.Theme.Customeraccount'}
             </a>
           {/if}
           {if $configuration.voucher_enabled && !$configuration.is_catalog}
             <a href="{$urls.pages.discount}" title="{l s='Vouchers' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">
-            <i class="material-icons me-2">&#xE54E;</i>
+            <i class="material-icons me-2" aria-hidden="true">&#xE54E;</i>
             {l s='Vouchers' d='Shop.Theme.Customeraccount'}
             </a>
           {/if}
           {if $configuration.return_enabled && !$configuration.is_catalog}
             <a href="{$urls.pages.order_follow}" title="{l s='Merchandise returns' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">
-              <i class="material-icons me-2">&#xE860;</i>
+              <i class="material-icons me-2" aria-hidden="true">&#xE860;</i>
               {l s='Merchandise returns' d='Shop.Theme.Customeraccount'}
             </a>
           {/if}
           <div class="dropdown-divider"></div>
           <a class="dropdown-item" href="{$logout_url}">
-            <i class="material-icons me-2">&#xE879;</i>
+            <i class="material-icons me-2" aria-hidden="true">&#xE879;</i>
             {l s='Sign out' d='Shop.Theme.Actions'}
           </a>
         </div>
@@ -79,7 +79,7 @@
           class="header-block__action-btn"
           rel="nofollow"
           role="button">
-          <i class="material-icons header-block__icon">&#xE7FD;</i>
+          <i class="material-icons header-block__icon" aria-hidden="true">&#xE7FD;</i>
           <span class="d-none d-md-inline header-block__title">{l s='Sign in' d='Shop.Theme.Actions'}</span>
         </a>
       </div>

--- a/modules/ps_emailalerts/views/templates/front/mailalerts-account-line.tpl
+++ b/modules/ps_emailalerts/views/templates/front/mailalerts-account-line.tpl
@@ -19,6 +19,6 @@
     class="js-remove-email-alert btn btn-link {$componentName}__remove"
     rel="js-id-emailalerts-{$mailAlert.id_product|intval}-{$mailAlert.id_product_attribute|intval}"
     data-url="{url entity='module' name='ps_emailalerts' controller='actions' params=['process' => 'remove']}">
-    <i class="material-icons">delete</i>
+    <i class="material-icons" aria-label="{l s='Delete' d='Modules.Emailalerts.Shop'}">delete</i>
   </a>
 </div>

--- a/modules/ps_emailalerts/views/templates/hook/my-account.tpl
+++ b/modules/ps_emailalerts/views/templates/hook/my-account.tpl
@@ -6,7 +6,7 @@
 <a class="col-md-6 col-lg-4" id="emailsalerts"
    href="{url entity='module' name='ps_emailalerts' controller='account'}" title="{l s='My alerts' d='Shop.Theme.Catalog'}">
   <span class="link-item">
-  <i class="material-icons">&#xE151;</i>
+    <i class="material-icons" aria-hidden="true">&#xE151;</i>
     {l s='My alerts' d='Shop.Theme.Catalog'}
   </span>
 </a>

--- a/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
+++ b/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
@@ -11,7 +11,7 @@
   <div class="featured-products-footer text-center">
     <a class="all-product-link btn btn-outline-primary btn-with-icon" href="{$allProductsLink}">
       {l s='All products' d='Shop.Theme.Catalog'}
-      <i class="material-icons rtl-flip">&#xE315;</i>
+      <i class="material-icons rtl-flip" aria-hidden="true">&#xE315;</i>
     </a>
   </div>
 </section>

--- a/modules/ps_legalcompliance/views/templates/hook/hookDisplayFooter.tpl
+++ b/modules/ps_legalcompliance/views/templates/hook/hookDisplayFooter.tpl
@@ -9,7 +9,7 @@
 
   <div class="footer__block__toggle d-md-none collapsed" data-target="#footer_eu_about_us_list" data-bs-toggle="collapse">
     <span class="footer__block__title">{l s='Information' d='Modules.Legalcompliance.Shop'}</span>
-    <i class="material-icons">arrow_drop_down</i>
+    <i class="material-icons" aria-hidden="true">arrow_drop_down</i>
   </div>
   <ul class="footer__block__content footer__block__content-list collapse" id="footer_eu_about_us_list">
     {foreach from=$cms_links item=cms_link}

--- a/modules/ps_linklist/views/templates/hook/linkblock-column.tpl
+++ b/modules/ps_linklist/views/templates/hook/linkblock-column.tpl
@@ -10,7 +10,7 @@
 
     <div class="footer__block__toggle d-md-none collapsed" data-target="#footer_sub_menu_{$linkBlock.id}" data-bs-toggle="collapse">
       <span class="footer__block__title">{$linkBlock.title}</span>
-      <i class="material-icons">arrow_drop_down</i>
+      <i class="material-icons" aria-hidden="true">arrow_drop_down</i>
     </div>
     <ul id="footer_sub_menu_{$linkBlock.id}" class="footer__block__content footer__block__content-list collapse">
       {foreach $linkBlock.links as $link}

--- a/modules/ps_linklist/views/templates/hook/linkblock.tpl
+++ b/modules/ps_linklist/views/templates/hook/linkblock.tpl
@@ -9,7 +9,7 @@
 
     <div class="footer__block__toggle d-md-none collapsed" aria-expanded="false" data-bs-target="#footer_sub_menu_{$linkBlock.id}" data-bs-toggle="collapse">
       <span class="footer__block__title">{$linkBlock.title}</span>
-      <i class="material-icons">arrow_drop_down</i>
+      <i class="material-icons" aria-hidden="true">arrow_drop_down</i>
     </div>
 
     <ul id="footer_sub_menu_{$linkBlock.id}" class="footer__block__content footer__block__content-list collapse">

--- a/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl
+++ b/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl
@@ -9,7 +9,7 @@
         {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
         <div class="new-products-footer text-center">
             <a class="all-product-link btn btn-outline-primary" href="{$allNewProductsLink}">
-                {l s='All new products' d='Shop.Theme.Catalog'}<i class="material-icons rtl-flip">&#xE315;</i>
+                {l s='All new products' d='Shop.Theme.Catalog'}<i class="material-icons rtl-flip" aria-hidden="true">&#xE315;</i>
             </a>
         </div>
     </div>

--- a/modules/ps_shoppingcart/modal.tpl
+++ b/modules/ps_shoppingcart/modal.tpl
@@ -8,7 +8,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <h4 class="modal-title" id="myModalLabel">
-          <i class="material-icons me-1">&#xE5CA;</i>
+          <i class="material-icons me-1" aria-hidden="true">&#xE5CA;</i>
           {l s='Product successfully added to your shopping cart' d='Shop.Theme.Checkout'}
         </h4>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{l s='Close' d='Shop.Theme.Global'}"></button>
@@ -98,7 +98,7 @@
       <div class="modal-footer border-1">
         <div class="cart-footer-actions d-flex flex-wrap align-items-center justify-content-between w-100">
           <button type="button" class="btn btn-outline-primary btn-with-icon w-md-auto w-100 mb-md-0 mb-3" data-bs-dismiss="modal">
-            <i class="material-icons rtl-flip">&#xE5CB;</i>
+            <i class="material-icons rtl-flip" aria-hidden="true">&#xE5CB;</i>
             {l s='Continue shopping' d='Shop.Theme.Actions'}
           </button>
           <a href="{$cart_url}" class="btn btn-primary w-md-auto w-100">{l s='Proceed to checkout' d='Shop.Theme.Actions'}</a>

--- a/modules/ps_shoppingcart/ps_shoppingcart.tpl
+++ b/modules/ps_shoppingcart/ps_shoppingcart.tpl
@@ -10,7 +10,7 @@
       <span class="header-block__action-btn">
     {/if}
 
-    <i class="material-icons header-block__icon">shopping_cart</i>
+    <i class="material-icons header-block__icon" aria-hidden="true">shopping_cart</i>
     <span class="d-none d-md-flex header-block__title">{l s='Cart' d='Shop.Theme.Checkout'}</span>
     <span class="header-block__badge">{$cart.products_count}</span>
 

--- a/modules/ps_specials/views/templates/hook/ps_specials.tpl
+++ b/modules/ps_specials/views/templates/hook/ps_specials.tpl
@@ -9,7 +9,7 @@
         {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
         <div class="sale-products-footer text-center">
             <a class="all-product-link btn btn-outline-primary" href="{$allSpecialProductsLink}">
-                {l s='All sale products' d='Shop.Theme.Catalog'}<i class="material-icons rtl-flip">&#xE315;</i>
+                {l s='All sale products' d='Shop.Theme.Catalog'}<i class="material-icons rtl-flip" aria-hidden="true">&#xE315;</i>
             </a>
         </div>
     </div>

--- a/modules/ps_supplierlist/views/templates/_partials/supplier_form.tpl
+++ b/modules/ps_supplierlist/views/templates/_partials/supplier_form.tpl
@@ -11,7 +11,7 @@
     aria-haspopup="true"
     aria-expanded="false">
     {l s='All suppliers' d='Shop.Theme.Catalog'}
-    <i class="material-icons float-end">arrow_drop_down</i>
+    <i class="material-icons float-end" aria-hidden="true">arrow_drop_down</i>
   </button>
   <div class="dropdown-menu dropdown-menu-start">
     {foreach from=$suppliers item=supplier}

--- a/modules/psgdpr/views/templates/front/customerPersonalData.tpl
+++ b/modules/psgdpr/views/templates/front/customerPersonalData.tpl
@@ -26,8 +26,8 @@
   <div class="mb-4">
     <h2 class="fs-5">{l s='Access to my data' mod='psgdpr'}</h2>
     <p>{l s='At any time, you have the right to retrieve the data you have provided to our site. Click on "Get my data" to automatically download a copy of your personal data on a pdf or csv file.' mod='psgdpr'}</p>
-    <a id="exportDataToCsv" class="btn btn-outline-primary d-block d-sm-inline-block mx-0 mb-2 mb-sm-0" target="_blank" href="{$psgdpr_csv_controller|escape:'htmlall':'UTF-8'}"><i class="material-icons">download</i> {l s='GET MY DATA TO CSV' mod='psgdpr'}</a>
-    <a id="exportDataToPdf" class="btn btn-outline-primary d-block d-sm-inline-block mx-0 mx-sm-2" target="_blank" href="{$psgdpr_pdf_controller|escape:'htmlall':'UTF-8'}"><i class="material-icons">download</i> {l s='GET MY DATA TO PDF' mod='psgdpr'}</a>
+    <a id="exportDataToCsv" class="btn btn-outline-primary d-block d-sm-inline-block mx-0 mb-2 mb-sm-0" target="_blank" href="{$psgdpr_csv_controller|escape:'htmlall':'UTF-8'}"><i class="material-icons" aria-hidden="true">download</i> {l s='GET MY DATA TO CSV' mod='psgdpr'}</a>
+    <a id="exportDataToPdf" class="btn btn-outline-primary d-block d-sm-inline-block mx-0 mx-sm-2" target="_blank" href="{$psgdpr_pdf_controller|escape:'htmlall':'UTF-8'}"><i class="material-icons" aria-hidden="true">download</i> {l s='GET MY DATA TO PDF' mod='psgdpr'}</a>
   </div>
 
   <h2 class="fs-5">{l s='Rectification & Erasure requests' mod='psgdpr'}</h2>

--- a/modules/psgdpr/views/templates/front/customerPersonalData.tpl
+++ b/modules/psgdpr/views/templates/front/customerPersonalData.tpl
@@ -26,8 +26,8 @@
   <div class="mb-4">
     <h2 class="fs-5">{l s='Access to my data' mod='psgdpr'}</h2>
     <p>{l s='At any time, you have the right to retrieve the data you have provided to our site. Click on "Get my data" to automatically download a copy of your personal data on a pdf or csv file.' mod='psgdpr'}</p>
-    <a id="exportDataToCsv" class="btn btn-outline-primary d-block d-sm-inline-block mx-0 mb-2 mb-sm-0" target="_blank" href="{$psgdpr_csv_controller|escape:'htmlall':'UTF-8'}"><i class="material-icons" aria-hidden="true">download</i> {l s='GET MY DATA TO CSV' mod='psgdpr'}</a>
-    <a id="exportDataToPdf" class="btn btn-outline-primary d-block d-sm-inline-block mx-0 mx-sm-2" target="_blank" href="{$psgdpr_pdf_controller|escape:'htmlall':'UTF-8'}"><i class="material-icons" aria-hidden="true">download</i> {l s='GET MY DATA TO PDF' mod='psgdpr'}</a>
+    <a id="exportDataToCsv" class="btn btn-outline-primary d-block d-sm-inline-block mx-0 mb-2 mb-sm-0" target="_blank" href="{$psgdpr_csv_controller|escape:'htmlall':'UTF-8'}"><i class="material-icons" aria-hidden="true">download</i> {l s='Get my data to CSV' mod='psgdpr'}</a>
+    <a id="exportDataToPdf" class="btn btn-outline-primary d-block d-sm-inline-block mx-0 mx-sm-2" target="_blank" href="{$psgdpr_pdf_controller|escape:'htmlall':'UTF-8'}"><i class="material-icons" aria-hidden="true">download</i> {l s='Get my data to PDF' mod='psgdpr'}</a>
   </div>
 
   <h2 class="fs-5">{l s='Rectification & Erasure requests' mod='psgdpr'}</h2>

--- a/src/js/components/useQuantityInput.ts
+++ b/src/js/components/useQuantityInput.ts
@@ -145,13 +145,13 @@ const updateQuantity = async (qtyInputGroup: Theme.QuantityInput.InputGroup, cha
                 (product: Record<string, unknown>) => data.id_product === Number(product.id_product)
                       && data.id_product_attribute === Number(product.id_product_attribute));
 
-              if (productData) {
-                if (productData.availability === 'unavailable'
-                    && productData.allow_oosp === 0
-                    && Number(productData.quantity_wanted) > Number(productData.stock_quantity)) {
-                  const diff = Number(productData.stock_quantity) - Number(productData.quantity_wanted);
-                  await sendUpdateCartRequest(productData.update_quantity_url as string, diff);
-                }
+              if (productData
+                  && productData.availability === 'unavailable'
+                  && productData.allow_oosp === 0
+                  && Number(productData.quantity_wanted) > Number(productData.stock_quantity)
+              ) {
+                const diff = Number(productData.stock_quantity) - Number(productData.quantity_wanted);
+                await sendUpdateCartRequest(productData.update_quantity_url as string, diff);
               }
             }
 

--- a/src/js/components/useQuantityInput.ts
+++ b/src/js/components/useQuantityInput.ts
@@ -159,11 +159,11 @@ const updateQuantity = async (qtyInputGroup: Theme.QuantityInput.InputGroup, cha
               reason: qtyInput.dataset,
               resp: data,
             });
+
             // Change the input value based on returned quantity
             qtyInput.value = data.quantity;
             // If user used the confirmation mode, need to update input value in the DOM
             qtyInput.setAttribute('value', data.quantity);
-
           } else {
             // Something went wrong so call the catch block
             throw response;

--- a/src/js/pages/checkout.ts
+++ b/src/js/pages/checkout.ts
@@ -170,9 +170,14 @@ const initCheckout = () => {
 
   const setMaxHeightToActiveCarrierExtraContent = () => {
     const activeExtraContent = document.querySelector(`${CheckoutMap.carrierExtraContentActive}`) as HTMLElement;
+
+    if (activeExtraContent === null) {
+      return;
+    }
+
     const content = activeExtraContent.querySelector(CheckoutMap.carrierExtraContent) as HTMLElement;
 
-    if (activeExtraContent != null && content != null) {
+    if (content != null) {
       activeExtraContent.style.maxHeight = `${content.clientHeight}px`;
     }
   };

--- a/src/js/visible-password.ts
+++ b/src/js/visible-password.ts
@@ -9,16 +9,24 @@ const initVisiblePassword = () => {
   const visiblePasswordList = document.querySelectorAll(visiblePasswordMap.visiblePassword);
 
   visiblePasswordList.forEach((input: HTMLInputElement) => {
-    const button = input?.nextElementSibling;
+    const button = input?.nextElementSibling as HTMLElement;
 
     button?.addEventListener('click', () => {
       const newType = input.getAttribute('type') === 'text' ? 'password' : 'text';
       input.setAttribute('type', newType);
+      button.setAttribute('aria-expanded', newType === 'text' ? 'true' : 'false');
 
       const icon = button.firstElementChild;
 
       if (icon) {
         icon.innerHTML = newType === 'text' ? 'visibility_off' : 'visibility';
+
+        const textShow = button.dataset.textShow;
+        const textHide = button.dataset.textHide;
+
+        if (textShow && textHide) {
+          button.setAttribute('aria-label', newType === 'text' ? textHide : textShow);
+        }
       }
     });
   });

--- a/src/js/visible-password.ts
+++ b/src/js/visible-password.ts
@@ -21,7 +21,7 @@ const initVisiblePassword = () => {
       if (icon) {
         icon.innerHTML = newType === 'text' ? 'visibility_off' : 'visibility';
 
-        const { textHide, textShow } = button.dataset;
+        const {textHide, textShow} = button.dataset;
 
         if (textShow && textHide) {
           button.setAttribute('aria-label', newType === 'text' ? textHide : textShow);

--- a/src/js/visible-password.ts
+++ b/src/js/visible-password.ts
@@ -21,8 +21,7 @@ const initVisiblePassword = () => {
       if (icon) {
         icon.innerHTML = newType === 'text' ? 'visibility_off' : 'visibility';
 
-        const textShow = button.dataset.textShow;
-        const textHide = button.dataset.textHide;
+        const { textHide, textShow } = button.dataset;
 
         if (textShow && textHide) {
           button.setAttribute('aria-label', newType === 'text' ? textHide : textShow);

--- a/src/scss/custom/components/_slider.scss
+++ b/src/scss/custom/components/_slider.scss
@@ -8,6 +8,7 @@ $component-name: carousel;
   & &-item {
     align-items: center;
     justify-content: center;
+    height: 100%;
 
     img {
       width: 100%;
@@ -94,5 +95,4 @@ $component-name: carousel;
   & &-control-next {
     right: 3rem;
   }
-
 }

--- a/src/scss/custom/components/_slider.scss
+++ b/src/scss/custom/components/_slider.scss
@@ -8,11 +8,6 @@ $component-name: carousel;
   & &-item {
     align-items: center;
     justify-content: center;
-    height: 100%;
-
-    &.active {
-      display: flex;
-    }
 
     img {
       width: 100%;
@@ -99,4 +94,5 @@ $component-name: carousel;
   & &-control-next {
     right: 3rem;
   }
+
 }

--- a/src/scss/custom/modules/_featuredproducts.scss
+++ b/src/scss/custom/modules/_featuredproducts.scss
@@ -3,7 +3,9 @@
     color: var(--bs-primary);
   }
 
-  &:hover {
+  &:hover,
+  &:focus,
+  &:focus-visible {
     i {
       color: var(--bs-white);
     }

--- a/src/scss/custom/pages/product/_product.scss
+++ b/src/scss/custom/pages/product/_product.scss
@@ -23,6 +23,23 @@
         overflow: hidden;
         border-radius: 8px;
       }
+
+      &__modal-opener {
+        position: absolute;
+        right: 0.635rem;
+        bottom: 0.635rem;
+        z-index: 10;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 2.5rem;
+        min-width: 2.5rem;
+        height: 2.5rem;
+        background-color: #fff;
+        border: none;
+        border-radius: 50%;
+        box-shadow: 0.125rem -0.125rem 0.25rem 0 rgb(0 0 0 / 20%);
+      }
     }
 
     &__description-short {

--- a/templates/_partials/form-fields.tpl
+++ b/templates/_partials/form-fields.tpl
@@ -145,8 +145,10 @@
             class="btn btn-primary"
             type="button"
             data-action="show-password"
-            data-text-show="{l s='Show' d='Shop.Theme.Actions'}"
-            data-text-hide="{l s='Hide' d='Shop.Theme.Actions'}"
+            data-text-show="{l s='Show Password' d='Shop.Theme.Actions'}"
+            data-text-hide="{l s='Hide Password' d='Shop.Theme.Actions'}"
+            aria-label="{l s='Show Password' d='Shop.Theme.Actions'}"
+            aria-expanded="false"
           >
             <i class="material-icons">visibility</i>
           </button>

--- a/templates/_partials/header.tpl
+++ b/templates/_partials/header.tpl
@@ -60,7 +60,7 @@
           {* JUST PLACEHOLDER FOR RESPONSIVE COMPONENT TO LOAD REAL ONE *}
           <div class="header-block">
             <span class="header-block__action-btn">
-              <i class="material-icons header-block__icon">&#xE7FD;</i>
+              <i class="material-icons header-block__icon" aria-hidden="true">&#xE7FD;</i>
               <span class="d-none d-md-inline header-block__title">{l s='Sign in' d='Shop.Theme.Actions'}</span>
             </span>
           </div>
@@ -71,7 +71,7 @@
           {* JUST PLACEHOLDER FOR RESPONSIVE COMPONENT TO LOAD REAL ONE *}
           <div class="header-block">
             <span class="header-block__action-btn">
-              <i class="material-icons header-block__icon">shopping_cart</i>
+              <i class="material-icons header-block__icon" aria-hidden="true">shopping_cart</i>
               <span class="header-block__badge">{$cart.products_count}</span>
             </span>
           </div>

--- a/templates/_partials/header.tpl
+++ b/templates/_partials/header.tpl
@@ -46,7 +46,7 @@
             </a>
           </div>
 
-          <div class="search__offcanvas js-search-offcanvas offcanvas offcanvas-top" data-bs-backdrop="false" data-bs-scroll="true" tabindex="-1" id="searchCanvas" aria-labelledby="offcanvasTopLabel">
+          <div class="search__offcanvas js-search-offcanvas offcanvas offcanvas-top h-auto" data-bs-backdrop="false" data-bs-scroll="true" tabindex="-1" id="searchCanvas" aria-labelledby="offcanvasTopLabel">
             <div class="offcanvas-header">
               <div id="_mobile_search" class="search__container"></div>
               <button type="button" class="btn-close text-reset ms-1" data-bs-dismiss="offcanvas" aria-label="Close">{l s='Cancel' d='Shop.Theme.Global'}</button>

--- a/templates/_partials/pagination.tpl
+++ b/templates/_partials/pagination.tpl
@@ -27,11 +27,11 @@
                     href="{$page.url}"
                     class="page-link btn-with-icon {if $page.type === 'previous'}previous {elseif $page.type === 'next'}next {/if}{['disabled' => !$page.clickable, 'js-search-link' => true]|classnames}">
                     {if $page.type === 'previous'}
-                      <i class="material-icons rtl-flip">&#xE314;</i>
+                      <i class="material-icons rtl-flip" aria-hidden="true">&#xE314;</i>
                       <span class="d-none d-md-flex">{l s='Previous' d='Shop.Theme.Actions'}</span>
                     {elseif $page.type === 'next'}
                       <span class="d-none d-md-flex">{l s='Next' d='Shop.Theme.Actions'}</span>
-                      <i class="material-icons rtl-flip">&#xE315;</i>
+                      <i class="material-icons rtl-flip" aria-hidden="true">&#xE315;</i>
                     {else}
                       {$page.page}
                     {/if}

--- a/templates/catalog/_partials/facets.tpl
+++ b/templates/catalog/_partials/facets.tpl
@@ -119,7 +119,7 @@
                         {l s='(no filter)' d='Shop.Theme.Global'}
                       {/if}
                     </span>
-                    <i class="material-icons">&#xE5C5;</i>
+                    <i class="material-icons" aria-hidden="true">&#xE5C5;</i>
                   </a>
                   <div class="dropdown-menu dropdown-menu-start">
                     {foreach from=$facet.filters item="filter"}

--- a/templates/catalog/_partials/facets.tpl
+++ b/templates/catalog/_partials/facets.tpl
@@ -12,7 +12,7 @@
       {if $activeFilters|count}
         <div id="_desktop_search_filters_clear_all" class="d-none d-sm-block d-md-block clear-all-wrapper">
           <button data-search-url="{$clear_all_link}" class="btn btn-tertiary js-search-filters-clear-all">
-            <i class="material-icons">&#xE14C;</i>
+            <i class="material-icons" aria-hidden="true">&#xE14C;</i>
             {l s='Clear all' d='Shop.Theme.Actions'}
           </button>
         </div>

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -114,7 +114,7 @@
           {block name='quick_view'}
             <div class="{$componentName}__quickview">
               <button class="{$componentName}__quickview_button btn btn-link js-quickview btn-with-icon" data-link-action="quickview">
-                <i class="material-icons">&#xE417;</i>
+                <i class="material-icons" aria-hidden="true">&#xE417;</i>
                 {l s='Quick view' d='Shop.Theme.Actions'}
               </button>
             </div>
@@ -183,7 +183,7 @@
                   }
                 </div>
                 <button data-button-action="add-to-cart" class="btn btn-primary ms-3">
-                  <i class="material-icons">&#xe854;</i>
+                  <i class="material-icons" aria-hidden="true">&#xe854;</i>
                   <span class="visually-hidden">{l s='Add to cart' d='Shop.Theme.Actions'}</span>
                 </button>
               </form>

--- a/templates/catalog/_partials/product-activation.tpl
+++ b/templates/catalog/_partials/product-activation.tpl
@@ -7,7 +7,7 @@
     <div class="container">
       {foreach $page.admin_notifications as $notif}
         <div>
-          <i class="material-icons">&#xE001;</i>
+          <i class="material-icons" aria-hidden="true">&#xE001;</i>
           <p class="alert-text">{$notif.message}</p>
         </div>
       {/foreach}

--- a/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/templates/catalog/_partials/product-add-to-cart.tpl
@@ -59,7 +59,7 @@
               disabled
             {/if}
          >
-            <i class="material-icons me-1">&#xE547;</i>
+            <i class="material-icons me-1" aria-hidden="true">&#xE547;</i>
             {l s='Add to cart' d='Shop.Theme.Actions'}
           </button>
         </div>
@@ -71,11 +71,11 @@
     {block name='product_minimal_quantity'}
       <p class="product__minimal-quantity product-minimal-quantity js-product-minimal-quantity d-flex align-items-center mt-3 mt-md-0">
         {if $product.minimal_quantity> 1}
-          <i class="material-icons me-2">&#xE88F;</i>
+          <i class="material-icons me-2" aria-hidden="true">&#xE88F;</i>
           {l
-          s='The minimum purchase order quantity for the product is %quantity%.'
-          d='Shop.Theme.Checkout'
-          sprintf=['%quantity%' => $product.minimal_quantity]
+            s='The minimum purchase order quantity for the product is %quantity%.'
+            d='Shop.Theme.Checkout'
+            sprintf=['%quantity%' => $product.minimal_quantity]
           }
         {/if}
       </p>

--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -5,8 +5,11 @@
 
 <div class="product__images js-images-container">
   {if $product.images|@count > 0}
-    <div id="product-images" class="carousel slide js-product-carousel"
-      data-bs-ride="carousel">
+    <div
+      id="product-images"
+      class="carousel slide js-product-carousel"
+      data-bs-ride="carousel"
+      >
 
       <div class="carousel-inner">
         {include file='catalog/_partials/product-flags.tpl'}
@@ -24,7 +27,10 @@
 
         {block name='product_cover'}
           {foreach from=$product.images item=image key=key name=productImages}
-            <div class="carousel-item{if $image.id_image == $product.default_image.id_image} active{/if}">
+            <div class="carousel-item{if $image.id_image == $product.default_image.id_image} active{/if}"
+              data-bs-target="#product-images-modal"
+              data-bs-slide-to="{$key}"
+              >
               <picture>
                 {if isset($image.bySize.default_md.sources.avif)}
                   <source 
@@ -64,6 +70,9 @@
                   data-full-size-image-url="{$image.bySize.home_default.url}"
                 >
               </picture>
+              <div class="product__images__modal-opener" data-bs-toggle="modal" data-bs-target="#product-modal">
+                <i class="material-icons zoom-in">search</i>
+              </div>
             </div>
           {/foreach}
         {/block}

--- a/templates/catalog/_partials/product-images-modal.tpl
+++ b/templates/catalog/_partials/product-images-modal.tpl
@@ -3,56 +3,72 @@
  * file that was distributed with this source code.
  *}
 <div class="modal fade js-product-images-modal" id="product-modal">
-  <div class="modal-dialog" role="document">
+  <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-body">
-        {assign var=imagesCount value=$product.images|count}
-        <figure>
-          {if $product.default_image}
-            <img
-              class="js-modal-product-cover product-cover-modal"
-              width="{$product.default_image.bySize.large_default.width}"
-              src="{$product.default_image.bySize.large_default.url}"
-              alt="{$product.default_image.legend}"
-              title="{$product.default_image.legend}"
-              height="{$product.default_image.bySize.large_default.height}"
-           >
-          {else}
-            <img src="{$urls.no_picture_image.bySize.large_default.url}" loading="lazy" width="{$urls.no_picture_image.bySize.large_default.width}" height="{$urls.no_picture_image.bySize.large_default.height}" />
-          {/if}
-          <figcaption class="image-caption">
-          {block name='product_description_short'}
-            <div id="product-description-short">{$product.description_short nofilter}</div>
-          {/block}
-        </figcaption>
-        </figure>
-        <aside id="thumbnails" class="thumbnails js-thumbnails text-sm-center">
-          {block name='product_images'}
-            <div class="js-modal-mask mask {if $imagesCount <= 5} nomargin {/if}">
-              <ul class="product-images js-modal-product-images">
-                {foreach from=$product.images item=image}
-                  <li class="thumb-container js-thumb-container">
-                    <img
-                      data-image-large-src="{$image.large.url}"
-                      class="thumb js-modal-thumb"
-                      src="{$image.medium.url}"
-                      alt="{$image.legend}"
-                      title="{$image.legend}"
-                      width="{$image.medium.width}"
-                      height="148"
-                   >
-                  </li>
-                {/foreach}
-              </ul>
-            </div>
-          {/block}
-          {if $imagesCount> 5}
-            <div class="arrows js-modal-arrows">
-              <i class="material-icons arrow-up js-modal-arrow-up">&#xE5C7;</i>
-              <i class="material-icons arrow-down js-modal-arrow-down">&#xE5C5;</i>
-            </div>
-          {/if}
-        </aside>
+        <div
+          id="product-images-modal"
+          class="carousel slide js-product-images-modal-carousel"
+          data-bs-ride="carousel"
+        >
+          <div class="carousel-inner">
+
+            {if $product.images|@count > 1}
+              <button class="carousel-control-prev" type="button" data-bs-target="#product-images-modal" data-bs-slide="prev">
+                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Previous</span>
+              </button>
+              <button class="carousel-control-next" type="button" data-bs-target="#product-images-modal" data-bs-slide="next">
+                <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Next</span>
+              </button>
+            {/if}
+
+            {foreach from=$product.images item=image key=key name=productImages}
+              <div class="carousel-item{if $image.id_image == $product.default_image.id_image} active{/if}">
+                <picture>
+                  {if isset($image.bySize.default_md.sources.avif)}
+                    <source 
+                      srcset="
+                        {$image.bySize.default_md.sources.avif} 320w,
+                        {$image.bySize.product_main.sources.avif} 720w,
+                        {$image.bySize.product_main_2x.sources.avif} 1440w"
+                      sizes="(min-width: 1300px) 720px, (min-width: 768px) 50vw, 100vw" 
+                      type="image/avif"
+                    >
+                  {/if}
+
+                  {if isset($image.bySize.default_md.sources.webp)}
+                    <source 
+                      srcset="
+                        {$image.bySize.default_md.sources.webp} 320w,
+                        {$image.bySize.product_main.sources.webp} 720w,
+                        {$image.bySize.product_main_2x.sources.webp} 1440w"
+                      sizes="(min-width: 1300px) 720px, (min-width: 768px) 50vw, 100vw" 
+                      type="image/webp"
+                    >
+                  {/if}
+
+                  <img
+                    class="img-fluid"
+                    srcset="
+                      {$image.bySize.default_md.url} 320w,
+                      {$image.bySize.product_main.url} 720w,
+                      {$image.bySize.product_main_2x.url} 1440w"
+                    sizes="(min-width: 1300px) 720px, (min-width: 768px) 50vw, 100vw" 
+                    src="{$image.bySize.product_main.url}" 
+                    width="{$image.bySize.product_main.width}"
+                    height="{$image.bySize.product_main.height}"
+                    loading="{if $smarty.foreach.productImages.first}eager{else}lazy{/if}"
+                    alt="{$image.legend}"
+                    title="{$image.legend}"
+                    data-full-size-image-url="{$image.bySize.home_default.url}"
+                  >
+                </picture>
+              </div>
+            {/foreach}
+          </div>
+        </div>
       </div>
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->

--- a/templates/catalog/_partials/products-top.tpl
+++ b/templates/catalog/_partials/products-top.tpl
@@ -21,7 +21,7 @@
         {if !empty($listing.rendered_facets)}
           <div class="col-4 d-block d-md-none filter-button">
             <button id="search_filter_toggler" class="btn btn-outline-primary btn-with-icon w-100 js-search-toggler" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-faceted">
-              <i class="material-icons">filter_list</i>
+              <i class="material-icons" aria-hidden="true">filter_list</i>
               {l s='Filter' d='Shop.Theme.Actions'}
             </button>
           </div>

--- a/templates/catalog/_partials/quickview.tpl
+++ b/templates/catalog/_partials/quickview.tpl
@@ -56,7 +56,7 @@
             {hook h='displayProductAdditionalInfo' product=$product}
           </div>
           <div class="product-additional-info--end">
-            <a href="{$product.url}" class="d-inline-flex align-items-center">{l s='All details' d='Shop.Theme.Catalog'} <div class="material-icons">chevron_right</div></a>
+            <a href="{$product.url}" class="d-inline-flex align-items-center">{l s='All details' d='Shop.Theme.Catalog'} <div class="material-icons" aria-hidden="true">chevron_right</div></a>
           </div>
         </div>
     </div>

--- a/templates/catalog/_partials/sort-orders.tpl
+++ b/templates/catalog/_partials/sort-orders.tpl
@@ -3,7 +3,7 @@
  * file that was distributed with this source code.
  *}
 
-<p class="d-none d-md-block sort-by m-0 me-3"><i class="material-icons">sort</i><span class="align-middle">{l s='Sort by:' d='Shop.Theme.Global'}</span></p>
+<p class="d-none d-md-block sort-by m-0 me-3"><i class="material-icons" aria-hidden="true">sort</i><span class="align-middle">{l s='Sort by:' d='Shop.Theme.Global'}</span></p>
 <div class="products-sort-order flex-grow-1 flex-grow-md-0 dropdown me-2 me-md-0">
   <button
     class="btn py-2 pe-3 select-title"

--- a/templates/checkout/_partials/cart-detailed-actions.tpl
+++ b/templates/checkout/_partials/cart-detailed-actions.tpl
@@ -3,16 +3,22 @@
  * file that was distributed with this source code.
  *}
 {block name='cart_detailed_actions'}
+    {$disableCheckout = false}
+    {foreach $cart.products as $product}
+        {if isset($product.availability) && $product.availability == 'unavailable' }
+            {$disableCheckout = true}
+        {/if}
+    {/foreach}
   <div class="checkout cart-detailed__actions js-cart-detailed-actions card-footer">
     {if $cart.minimalPurchaseRequired}
       <div class="alert alert-warning" role="alert">
         {$cart.minimalPurchaseRequired}
       </div>
-      <div class="text-sm-center">
+      <div class="text-sm-center d-grid">
         <button type="button" class="btn btn-primary disabled" disabled>{l s='Proceed to checkout' d='Shop.Theme.Actions'}</button>
       </div>
-    {elseif empty($cart.products) }
-      <div class="text-sm-center">
+    {elseif empty($cart.products) || $disableCheckout === true}
+      <div class="text-sm-center d-grid">
         <button type="button" class="btn btn-primary disabled" disabled>{l s='Proceed to checkout' d='Shop.Theme.Actions'}</button>
       </div>
     {else}

--- a/templates/checkout/_partials/cart-summary-products.tpl
+++ b/templates/checkout/_partials/cart-summary-products.tpl
@@ -11,7 +11,7 @@
       <span>
         {l s='Show details' d='Shop.Theme.Actions'}
       </span>
-      <i class="material-icons">expand_more</i>
+      <i class="material-icons" aria-hidden="true">expand_more</i>
     </a>
   </p>
 

--- a/templates/checkout/_partials/cart-voucher.tpl
+++ b/templates/checkout/_partials/cart-voucher.tpl
@@ -16,7 +16,7 @@
                 <div class="d-flex align-items-center justify-content-end col">
                   <span class="fw-bold">{$voucher.reduction_formatted}</span>
                     {if isset($voucher.code) && $voucher.code !== ''}
-                      <a href="{$voucher.delete_url}" class="ms-2" data-link-action="remove-voucher"><i class="material-icons">&#xE872;</i></a>
+                      <a href="{$voucher.delete_url}" class="ms-2" data-link-action="remove-voucher"><i class="material-icons" title="{l s='Remove Voucher' d='Shop.Theme.Checkout'}">&#xE872;</i></a>
                     {/if}
                 </div>
               </li>

--- a/templates/checkout/_partials/cart-voucher.tpl
+++ b/templates/checkout/_partials/cart-voucher.tpl
@@ -46,7 +46,7 @@
 
               {block name='cart_voucher_notifications'}
                 <div class="alert alert-danger js-error mt-2" role="alert" style="display: none;">
-                  <i class="material-icons">&#xE001;</i><span class="ml-1 js-error-text"></span>
+                  <i class="material-icons" aria-hidden="true">&#xE001;</i><span class="ml-1 js-error-text"></span>
                 </div>
               {/block}
             </div>

--- a/templates/checkout/_partials/order-final-summary-table.tpl
+++ b/templates/checkout/_partials/order-final-summary-table.tpl
@@ -12,7 +12,7 @@
       {else}
         {l s='%products_count% items in your cart' sprintf=['%products_count%' => $products_count] d='Shop.Theme.Checkout'}
       {/if}
-      <a href="{url entity=cart params=['action' => 'show']}"><span class="step-edit"><i class="material-icons edit">mode_edit</i> {l s='edit' d='Shop.Theme.Actions'}</span></a>
+      <a href="{url entity=cart params=['action' => 'show']}"><span class="step-edit"><i class="material-icons edit" aria-hidden="true">mode_edit</i> {l s='edit' d='Shop.Theme.Actions'}</span></a>
     </h3>
   </div>
 {/block}

--- a/templates/checkout/_partials/order-final-summary.tpl
+++ b/templates/checkout/_partials/order-final-summary.tpl
@@ -10,7 +10,7 @@
   <div class="order__summary__addresses mb-4">
     <h5 class="mb-3">
       {l s='Addresses' d='Shop.Theme.Checkout'}
-      <span class="btn step-edit step-to-addresses fs-6 text-gray js-edit-addresses" data-step="checkout-addresses-step"><i class="material-icons edit fs-6">mode_edit</i> {l s='edit' d='Shop.Theme.Actions'}</span>
+      <span class="btn step-edit step-to-addresses fs-6 text-gray js-edit-addresses" data-step="checkout-addresses-step"><i class="material-icons edit fs-6" aria-hidden="true">mode_edit</i> {l s='edit' d='Shop.Theme.Actions'}</span>
     </h5>
 
     <div class="row">
@@ -75,7 +75,7 @@
   {if !$cart.is_virtual}
     <h5 class="mb-3">
       {l s='Shipping Method' d='Shop.Theme.Checkout'}
-      <span class="btn step-edit step-to-addresses fs-6 text-gray js-edit-shipping" data-step="checkout-delivery-step"><i class="material-icons edit fs-6">mode_edit</i> {l s='edit' d='Shop.Theme.Actions'}</span>
+      <span class="btn step-edit step-to-addresses fs-6 text-gray js-edit-shipping" data-step="checkout-delivery-step"><i class="material-icons edit fs-6" aria-hidden="true">mode_edit</i> {l s='edit' d='Shop.Theme.Actions'}</span>
     </h5>
 
     <div class="bg-light rounded-3 p-3 mb-4">

--- a/templates/checkout/_partials/steps/addresses.tpl
+++ b/templates/checkout/_partials/steps/addresses.tpl
@@ -50,7 +50,7 @@
         {/if}
 
         <a href="{$new_address_delivery_url}" class="btn btn-outline-primary btn-with-icon w-100 w-md-auto mb-3">
-          <i class="material-icons">&#xE145;</i>
+          <i class="material-icons" aria-hidden="true">&#xE145;</i>
           {l s='Add new address' d='Shop.Theme.Actions'}
         </a>
 
@@ -91,7 +91,7 @@
           {/if}
 
           <a href="{$new_address_invoice_url}" class="btn btn-outline-primary btn-with-icon w-100 w-md-auto">
-            <i class="material-icons">&#xE145;</i>
+            <i class="material-icons" aria-hidden="true">&#xE145;</i>
             {l s='Add new address' d='Shop.Theme.Actions'}
           </a>
         {/if}
@@ -100,14 +100,14 @@
 
       <div class="mt-4 d-flex flex-wrap justify-content-between">
         <button class="btn btn-outline-primary btn-with-icon w-100 w-md-auto mb-3 mb-md-0 js-back" data-step="checkout-personal-information-step">
-          <i class="material-icons rtl-flip">arrow_backward</i>
+          <i class="material-icons rtl-flip" aria-hidden="true">arrow_backward</i>
           {l s='Back to Personal Information' d='Shop.Theme.Actions'}
         </button>
 
         {if !$form_has_continue_button}
             <button type="submit" class="btn btn-primary btn-with-icon w-100 w-md-auto continue" name="confirm-addresses" value="1">
               {l s='Continue to Shipping' d='Shop.Theme.Actions'}
-              <div class="material-icons rtl-flip">arrow_forward</div>
+              <div class="material-icons rtl-flip" aria-hidden="true">arrow_forward</div>
             </button>
             <input type="hidden" id="not-valid-addresses" class="js-not-valid-addresses" value="{$not_valid_addresses}">
         {/if}

--- a/templates/checkout/_partials/steps/payment.tpl
+++ b/templates/checkout/_partials/steps/payment.tpl
@@ -131,7 +131,7 @@
 
   <div class="payment__actions d-block d-md-flex d-flex flex-wrap justify-content-between">
     <button class="btn btn-outline-primary btn-with-icon w-100 w-md-auto mb-3 mb-md-0 js-back" data-step="checkout-delivery-step">
-      <div class="material-icons rtl-flip">arrow_backward</div>
+      <div class="material-icons rtl-flip" aria-hidden="true">arrow_backward</div>
       {l s='Back to Shipping method' d='Shop.Theme.Actions'}
     </button>
 
@@ -140,7 +140,7 @@
         <div class="payment__actions">
           <button type="submit" class="btn btn-primary btn-with-icon w-100{if !$selected_payment_option} disabled{/if}">
             {l s='Place order' d='Shop.Theme.Checkout'}
-            <div class="material-icons rtl-flip">arrow_forward</div>
+            <div class="material-icons rtl-flip" aria-hidden="true">arrow_forward</div>
           </button>
         </div>
       </div>

--- a/templates/checkout/_partials/steps/personal-information.tpl
+++ b/templates/checkout/_partials/steps/personal-information.tpl
@@ -44,7 +44,7 @@
           value="order"
        > 
           {l s='Continue to Addresses' d='Shop.Theme.Actions'}
-          <div class="material-icons rtl-flip">arrow_forward</div>
+          <div class="material-icons rtl-flip" aria-hidden="true">arrow_forward</div>
         </button>
       </form>
     </div>

--- a/templates/checkout/_partials/steps/shipping.tpl
+++ b/templates/checkout/_partials/steps/shipping.tpl
@@ -99,13 +99,13 @@
 
         <div class="shipping__actions d-flex flex-wrap justify-content-between">
           <button class="btn btn-outline-primary btn-with-icon w-100 w-md-auto mb-3 mb-md-0 js-back" data-step="checkout-addresses-step">
-            <div class="material-icons rtl-flip">arrow_backward</div>
+            <div class="material-icons rtl-flip" aria-hidden="true">arrow_backward</div>
             {l s='Back to Addresses' d='Shop.Theme.Actions'}
           </button>
 
           <button type="submit" class="btn btn-primary btn-with-icon w-100 w-md-auto" name="confirmDeliveryOption" value="1">
             {l s='Continue to Payment' d='Shop.Theme.Actions'}
-            <div class="material-icons rtl-flip">arrow_forward</div>
+            <div class="material-icons rtl-flip" aria-hidden="true">arrow_forward</div>
           </button>
         </div>
       </form>

--- a/templates/checkout/cart-empty.tpl
+++ b/templates/checkout/cart-empty.tpl
@@ -6,7 +6,7 @@
 
 {block name='continue_shopping' append}
   <a class="btn btn-outline-primary btn-with-icon" href="{$urls.pages.index}">
-    <i class="material-icons rtl-flip">chevron_left</i>
+    <i class="material-icons rtl-flip" aria-hidden="true">chevron_left</i>
     {l s='Continue shopping' d='Shop.Theme.Actions'}
   </a>
 {/block}

--- a/templates/checkout/cart.tpl
+++ b/templates/checkout/cart.tpl
@@ -18,7 +18,7 @@
 
         {block name='continue_shopping'}
           <a class="btn btn-outline-primary btn-with-icon" href="{$urls.pages.index}">
-            <i class="material-icons rtl-flip">chevron_left</i>
+            <i class="material-icons rtl-flip" aria-hidden="true">chevron_left</i>
             {l s='Continue shopping' d='Shop.Theme.Actions'}
           </a>
         {/block}

--- a/templates/cms/_partials/sitemap-nested-list.tpl
+++ b/templates/cms/_partials/sitemap-nested-list.tpl
@@ -2,13 +2,15 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *}
+
 {block name='sitemap_item'}
-  <ul{if !empty($is_nested)} class="nested"{/if}>
+  <ul {if !empty($is_nested)}class="nested"{/if}>
     {foreach $links as $link}
       <li>
         <a id="{$link.id}" href="{$link.url}" title="{$link.label}">
           {$link.label}
         </a>
+
         {if !empty($link.children)}
           {include file='cms/_partials/sitemap-nested-list.tpl' links=$link.children is_nested=true}
         {/if}

--- a/templates/cms/category.tpl
+++ b/templates/cms/category.tpl
@@ -2,6 +2,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *}
+
 {extends file='page.tpl'}
 
 {block name='page_title'}
@@ -11,10 +12,17 @@
 {block name='page_content'}
   {block name='cms_sub_categories'}
     {if $sub_categories}
-      <p>{l s='List of sub categories in %name%:' d='Shop.Theme.Global' sprintf=['%name%' => $cms_category.name]}</p>
+      <p>
+        {l s='List of sub categories in %name%:' d='Shop.Theme.Global' sprintf=['%name%' => $cms_category.name]}
+      </p>
+
       <ul>
         {foreach from=$sub_categories item=sub_category}
-          <li><a href="{$sub_category.link}">{$sub_category.name}</a></li>
+          <li>
+            <a href="{$sub_category.link}">
+              {$sub_category.name}
+            </a>
+          </li>
         {/foreach}
       </ul>
     {/if}
@@ -22,10 +30,17 @@
 
   {block name='cms_sub_pages'}
     {if $cms_pages}
-      <p>{l s='List of pages in %category_name%:' d='Shop.Theme.Global' sprintf=['%category_name%' => $cms_category.name]}</p>
+      <p>
+        {l s='List of pages in %category_name%:' d='Shop.Theme.Global' sprintf=['%category_name%' => $cms_category.name]}
+      </p>
+
       <ul>
         {foreach from=$cms_pages item=cms_page}
-          <li><a href="{$cms_page.link}">{$cms_page.meta_title}</a></li>
+          <li>
+            <a href="{$cms_page.link}">
+              {$cms_page.meta_title}
+            </a>
+          </li>
         {/foreach}
       </ul>
     {/if}

--- a/templates/cms/page.tpl
+++ b/templates/cms/page.tpl
@@ -2,6 +2,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *}
+
 {extends file='page.tpl'}
 
 {block name='page_title'}

--- a/templates/cms/sitemap.tpl
+++ b/templates/cms/sitemap.tpl
@@ -2,6 +2,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *}
+
 {extends file='page.tpl'}
 
 {block name='page_title'}
@@ -12,9 +13,13 @@
   <div class="row sitemap">
     {foreach $sitemapUrls as $group}
       <div class="col-md-6 col-lg-3">
-        <h2 class="h3">{$group.name}</h2>
+        <h2 class="h3">
+          {$group.name}
+        </h2>
+
         {include file='cms/_partials/sitemap-nested-list.tpl' links=$group.links}
-        <hr class="d-block d-md-none" />
+
+        <hr class="d-block d-md-none">
       </div>
     {/foreach}
   </div>

--- a/templates/cms/stores.tpl
+++ b/templates/cms/stores.tpl
@@ -2,6 +2,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *}
+
 {extends file='page.tpl'}
 
 {block name='page_title'}
@@ -51,69 +52,114 @@
                     {/if}
                 </picture>
               </div>
+
               <div class="col-xl-6 store__description d-none d-md-block">
-                <h2 class="h6 store__name">{$store.name}</h2>
-                <address class="store__address">{$store.address.formatted nofilter}</address>
+                <h2 class="h6 store__name">
+                  {$store.name}
+                </h2>
+
+                <address class="store__address">
+                  {$store.address.formatted nofilter}
+                </address>
+
                 {if $store.note || $store.phone || $store.fax || $store.email}
-                  <a data-bs-toggle="collapse" href="#about-{$store.id}" aria-expanded="false" aria-controls="about-{$store.id}"><strong>{l s='About and Contact' d='Shop.Theme.Global'}</strong><i class="material-icons" aria-hidden="true">&#xE409;</i></a>
+                  <a data-bs-toggle="collapse" href="#about-{$store.id}" aria-expanded="false" aria-controls="about-{$store.id}">
+                    <strong>{l s='About and Contact' d='Shop.Theme.Global'}</strong><i class="material-icons" aria-hidden="true">&#xE409;</i>
+                  </a>
                 {/if}
+
                 <hr>
+
                 <table class="store__opening-times">
                   {foreach $store.business_hours as $day}
-                  <tr>
-                    <th>{$day.day|truncate:4:'.'}</th>
-                    <td>
-                      <ul>
-                      {foreach $day.hours as $h}
-                        <li>{$h}</li>
-                      {/foreach}
-                      </ul>
-                    </td>
-                  </tr>
-                  {/foreach}
-                </table>
-              </div>
-              <div class="store__description accordion d-block d-md-none">
-                <div class="accordion-item">
-                  <h2 class="h6 store__name">{$store.name}</h2>
-                  <address class="store__address">{$store.address.formatted nofilter}</address>
-                  {if $store.note || $store.phone || $store.fax || $store.email}
-                    <a data-bs-toggle="collapse" href="#about-{$store.id}" aria-expanded="false" aria-controls="about-{$store.id}"><strong>{l s='About and Contact' d='Shop.Theme.Global'}</strong><i class="material-icons" aria-hidden="true">&#xE409;</i></a>
-                  {/if}
-                  <hr>
-                  <button class="store__toggle accordion-button collapsed pb-2 px-0" data-bs-toggle="collapse" data-bs-target="#table-{$store.id}">{l s='View schedules' d='Shop.Theme.Global'}</button>
-                  <table id="table-{$store.id}" class="store__opening-times accordion-collapse collapse">
-                    {foreach $store.business_hours as $day}
                     <tr>
-                      <th>{$day.day|truncate:4:'.'}</th>
+                      <th>
+                        {$day.day|truncate:4:'.'}
+                      </th>
+
                       <td>
                         <ul>
-                        {foreach $day.hours as $h}
-                          <li>{$h}</li>
-                        {/foreach}
+                          {foreach $day.hours as $h}
+                            <li>
+                              {$h}
+                            </li>
+                          {/foreach}
                         </ul>
                       </td>
                     </tr>
+                  {/foreach}
+                </table>
+              </div>
+
+              <div class="store__description accordion d-block d-md-none">
+                <div class="accordion-item">
+                  <h2 class="h6 store__name">
+                    {$store.name}
+                  </h2>
+
+                  <address class="store__address">
+                    {$store.address.formatted nofilter}
+                  </address>
+
+                  {if $store.note || $store.phone || $store.fax || $store.email}
+                    <a data-bs-toggle="collapse" href="#about-{$store.id}" aria-expanded="false" aria-controls="about-{$store.id}">
+                      <strong>{l s='About and Contact' d='Shop.Theme.Global'}</strong><i class="material-icons" aria-hidden="true">&#xE409;</i>
+                    </a>
+                  {/if}
+
+                  <hr>
+
+                  <button class="store__toggle accordion-button collapsed pb-2 px-0" data-bs-toggle="collapse" data-bs-target="#table-{$store.id}">
+                    {l s='View schedules' d='Shop.Theme.Global'}
+                  </button>
+
+                  <table id="table-{$store.id}" class="store__opening-times accordion-collapse collapse">
+                    {foreach $store.business_hours as $day}
+                      <tr>
+                        <th>
+                          {$day.day|truncate:4:'.'}
+                        </th>
+
+                        <td>
+                          <ul>
+                            {foreach $day.hours as $h}
+                              <li>
+                                {$h}
+                              </li>
+                            {/foreach}
+                          </ul>
+                        </td>
+                      </tr>
                     {/foreach}
                   </table>
                 </div>
               </div>
             </div>
           </div>
+
           {if $store.note || $store.phone || $store.fax || $store.email}
             <div class="card-footer store__footer collapse" id="about-{$store.id}">
               {if $store.note}
                   <p class="store__note">{$store.note}</p>
               {/if}
+
               <ul class="store__contacts">
                 {if $store.phone}
-                  <li><i class="material-icons" aria-hidden="true">&#xE0B0;</i>{$store.phone}</li>
+                  <li>
+                    <i class="material-icons" aria-hidden="true">&#xE0B0;</i>{$store.phone}
+                  </li>
                 {/if}
+
                 {if $store.fax}
-                  <li><i class="material-icons" aria-hidden="true">&#xE8AD;</i>{$store.fax}</li>
+                  <li>
+                    <i class="material-icons" aria-hidden="true">&#xE8AD;</i>{$store.fax}
+                  </li>
                 {/if}
+
                 {if $store.email}
-                  <li><i class="material-icons" aria-hidden="true">&#xE0BE;</i>{$store.email}</li>
+                  <li>
+                    <i class="material-icons" aria-hidden="true">&#xE0BE;</i>{$store.email}
+                  </li>
                 {/if}
               </ul>
             </div>

--- a/templates/cms/stores.tpl
+++ b/templates/cms/stores.tpl
@@ -55,7 +55,7 @@
                 <h2 class="h6 store__name">{$store.name}</h2>
                 <address class="store__address">{$store.address.formatted nofilter}</address>
                 {if $store.note || $store.phone || $store.fax || $store.email}
-                  <a data-bs-toggle="collapse" href="#about-{$store.id}" aria-expanded="false" aria-controls="about-{$store.id}"><strong>{l s='About and Contact' d='Shop.Theme.Global'}</strong><i class="material-icons">&#xE409;</i></a>
+                  <a data-bs-toggle="collapse" href="#about-{$store.id}" aria-expanded="false" aria-controls="about-{$store.id}"><strong>{l s='About and Contact' d='Shop.Theme.Global'}</strong><i class="material-icons" aria-hidden="true">&#xE409;</i></a>
                 {/if}
                 <hr>
                 <table class="store__opening-times">
@@ -78,7 +78,7 @@
                   <h2 class="h6 store__name">{$store.name}</h2>
                   <address class="store__address">{$store.address.formatted nofilter}</address>
                   {if $store.note || $store.phone || $store.fax || $store.email}
-                    <a data-bs-toggle="collapse" href="#about-{$store.id}" aria-expanded="false" aria-controls="about-{$store.id}"><strong>{l s='About and Contact' d='Shop.Theme.Global'}</strong><i class="material-icons">&#xE409;</i></a>
+                    <a data-bs-toggle="collapse" href="#about-{$store.id}" aria-expanded="false" aria-controls="about-{$store.id}"><strong>{l s='About and Contact' d='Shop.Theme.Global'}</strong><i class="material-icons" aria-hidden="true">&#xE409;</i></a>
                   {/if}
                   <hr>
                   <button class="store__toggle accordion-button collapsed pb-2 px-0" data-bs-toggle="collapse" data-bs-target="#table-{$store.id}">{l s='View schedules' d='Shop.Theme.Global'}</button>
@@ -107,13 +107,13 @@
               {/if}
               <ul class="store__contacts">
                 {if $store.phone}
-                  <li><i class="material-icons">&#xE0B0;</i>{$store.phone}</li>
+                  <li><i class="material-icons" aria-hidden="true">&#xE0B0;</i>{$store.phone}</li>
                 {/if}
                 {if $store.fax}
-                  <li><i class="material-icons">&#xE8AD;</i>{$store.fax}</li>
+                  <li><i class="material-icons" aria-hidden="true">&#xE8AD;</i>{$store.fax}</li>
                 {/if}
                 {if $store.email}
-                  <li><i class="material-icons">&#xE0BE;</i>{$store.email}</li>
+                  <li><i class="material-icons" aria-hidden="true">&#xE0BE;</i>{$store.email}</li>
                 {/if}
               </ul>
             </div>

--- a/templates/components/account-menu.tpl
+++ b/templates/components/account-menu.tpl
@@ -9,7 +9,7 @@
     <p class="{$componentName}__title mb-4 h4">{l s='My Account' d='Shop.Theme.Customeraccount'}</p>
     <a class="{$componentName}__line{if $urls.current_url === $urls.pages.identity} active{/if}" id="identity__link" href="{$urls.pages.identity}">
       <span class="link-item">
-      <i class="material-icons">&#xE853;</i>
+      <i class="material-icons" aria-hidden="true">&#xE853;</i>
         {l s='Information' d='Shop.Theme.Customeraccount'}
       </span>
     </a>
@@ -17,14 +17,14 @@
     {if $customer.addresses|count}
       <a class="{$componentName}__line{if $urls.current_url === $urls.pages.addresses} active{/if}" id="addresses__link" href="{$urls.pages.addresses}">
         <span class="link-item">
-          <i class="material-icons">&#xE56A;</i>
+          <i class="material-icons" aria-hidden="true">&#xE56A;</i>
           {l s='Addresses' d='Shop.Theme.Customeraccount'}
         </span>
       </a>
     {else}
       <a class="{$componentName}__line{if $urls.current_url === $urls.pages.address} active{/if}" id="address__link" href="{$urls.pages.address}">
         <span class="link-item">
-          <i class="material-icons">&#xE567;</i>
+          <i class="material-icons" aria-hidden="true">&#xE567;</i>
           {l s='Add first address' d='Shop.Theme.Customeraccount'}
         </span>
       </a>
@@ -33,7 +33,7 @@
     {if !$configuration.is_catalog}
       <a class="{$componentName}__line{if $urls.current_url === $urls.pages.history} active{/if}" id="history__link" href="{$urls.pages.history}">
         <span class="link-item">
-          <i class="material-icons">&#xE916;</i>
+          <i class="material-icons" aria-hidden="true">&#xE916;</i>
           {l s='Order history and details' d='Shop.Theme.Customeraccount'}
         </span>
       </a>
@@ -42,7 +42,7 @@
     {if !$configuration.is_catalog}
       <a class="{$componentName}__line{if $urls.current_url === $urls.pages.order_slip} active{/if}" id="order-slips__link" href="{$urls.pages.order_slip}">
         <span class="link-item">
-          <i class="material-icons">&#xE8B0;</i>
+          <i class="material-icons" aria-hidden="true">&#xE8B0;</i>
           {l s='Credit slips' d='Shop.Theme.Customeraccount'}
         </span>
       </a>
@@ -51,7 +51,7 @@
     {if $configuration.voucher_enabled && !$configuration.is_catalog}
       <a class="{$componentName}__line{if $urls.current_url === $urls.pages.discount} active{/if}" id="discounts__link" href="{$urls.pages.discount}">
         <span class="link-item">
-          <i class="material-icons">&#xE54E;</i>
+          <i class="material-icons" aria-hidden="true">&#xE54E;</i>
           {l s='Vouchers' d='Shop.Theme.Customeraccount'}
         </span>
       </a>
@@ -60,7 +60,7 @@
     {if $configuration.return_enabled && !$configuration.is_catalog}
       <a class="{$componentName}__line{if $urls.current_url === $urls.pages.order_follow} active{/if}" id="returns__link" href="{$urls.pages.order_follow}">
         <span class="link-item">
-          <i class="material-icons">&#xE860;</i>
+          <i class="material-icons" aria-hidden="true">&#xE860;</i>
           {l s='Merchandise returns' d='Shop.Theme.Customeraccount'}
         </span>
       </a>
@@ -72,7 +72,7 @@
 
     <a class="{$componentName}__line{if $urls.current_url === $urls.pages.order_follow} active{/if} {$componentName}--signout" id="returns__link" href="{$urls.actions.logout}">
       <span class="link-item">
-        <i class="material-icons">exit_to_app</i>
+        <i class="material-icons" aria-hidden="true">exit_to_app</i>
         {l s='Sign out' d='Shop.Theme.Actions'}
       </span>
     </a>

--- a/templates/components/qty-input.tpl
+++ b/templates/components/qty-input.tpl
@@ -20,7 +20,7 @@
 
 <div class="input-group flex-nowrap{if isset($marginHelper)} {$marginHelper}{else} mb-3{/if}">
   <button class="btn {$prepend.button} js-{$prepend.button}-button" type="button">
-    <i class="material-icons">&#x{$prepend.icon};</i>
+    <i class="material-icons" aria-hidden="true">&#x{$prepend.icon};</i>
     <i class="material-icons confirmation d-none">&#x{$prepend.confirm_icon};</i>
     <div class="spinner-border spinner-border-sm align-middle d-none" role="status"></div>
   </button>
@@ -40,7 +40,7 @@
     {* End of default attributes *}
   />
   <button class="btn {$append.button} js-{$append.button}-button" type="button">
-    <i class="material-icons">&#x{$append.icon};</i>
+    <i class="material-icons" aria-hidden="true">&#x{$append.icon};</i>
     <i class="material-icons confirmation d-none">&#x{$append.confirm_icon};</i>
     <div class="spinner-border spinner-border-sm align-middle d-none" role="status"></div>
   </button>

--- a/templates/customer/_partials/my-account-links.tpl
+++ b/templates/customer/_partials/my-account-links.tpl
@@ -4,11 +4,11 @@
  *}
 {block name='my_account_links'}
   <a href="{$urls.pages.my_account}" class="account-link" data-role="back-to-your-account">
-    <i class="material-icons">&#xE5CB;</i>
+    <i class="material-icons" aria-hidden="true">&#xE5CB;</i>
     <span>{l s='Back to your account' d='Shop.Theme.Customeraccount'}</span>
   </a>
   <a href="{$urls.pages.index}" class="account-link" data-role="home">
-    <i class="material-icons">&#xE88A;</i>
+    <i class="material-icons" aria-hidden="true">&#xE88A;</i>
     <span>{l s='Home' d='Shop.Theme.Global'}</span>
   </a>
 {/block}

--- a/templates/customer/addresses.tpl
+++ b/templates/customer/addresses.tpl
@@ -21,7 +21,7 @@
       <a class="addresses__new-address" href="{$urls.pages.address}" data-link-action="add-address">
         <span class="new-address__text">{l s='Add new address' d='Shop.Theme.Actions'}</span>
         <div class="new-address__icon">
-          <i class="material-icons">&#xE145;</i>
+          <i class="material-icons" aria-hidden="true">&#xE145;</i>
         </div>
       </a>
     </div>

--- a/templates/customer/history.tpl
+++ b/templates/customer/history.tpl
@@ -42,7 +42,7 @@
               </td>
               <td class="text-sm-center d-none d-lg-table-cell">
                 {if $order.details.invoice_url}
-                  <a href="{$order.details.invoice_url}"><i class="material-icons">&#xE415;</i></a>
+                  <a href="{$order.details.invoice_url}"><i class="material-icons" aria-label="{l s='Open Invoice' d='Shop.Theme.Actions'}">&#xE415;</i></a>
                 {else}
                   -
                 {/if}
@@ -102,7 +102,7 @@
             <p class="order__label">{l s='Invoice' d='Shop.Theme.Checkout'}</p> 
             <p class="order__value">
               {if $order.details.invoice_url}
-                <a href="{$order.details.invoice_url}"><i class="material-icons">&#xE415;</i></a>
+                <a href="{$order.details.invoice_url}"><i class="material-icons" aria-label="{l s='Open Invoice' d='Shop.Theme.Actions'}">&#xE415;</i></a>
               {else}
                 -
               {/if}

--- a/templates/customer/my-account.tpl
+++ b/templates/customer/my-account.tpl
@@ -14,7 +14,7 @@
   <div class="{$componentName} row g-3">
     <a class="{$componentName}__link col-md-6 col-lg-4" id="identity-link" href="{$urls.pages.identity}">
       <span class="link-item">
-        <i class="material-icons">&#xE853;</i>
+        <i class="material-icons" aria-hidden="true">&#xE853;</i>
         {l s='Information' d='Shop.Theme.Customeraccount'}
       </span>
     </a>
@@ -22,14 +22,14 @@
     {if $customer.addresses|count}
       <a class="{$componentName}__link col-md-6 col-lg-4" id="addresses-link" href="{$urls.pages.addresses}">
         <span class="link-item">
-          <i class="material-icons">&#xE56A;</i>
+          <i class="material-icons" aria-hidden="true">&#xE56A;</i>
           {l s='Addresses' d='Shop.Theme.Customeraccount'}
         </span>
       </a>
     {else}
       <a class="{$componentName}__link col-md-6 col-lg-4" id="address-link" href="{$urls.pages.address}">
         <span class="link-item">
-          <i class="material-icons">&#xE567;</i>
+          <i class="material-icons" aria-hidden="true">&#xE567;</i>
           {l s='Add first address' d='Shop.Theme.Customeraccount'}
         </span>
       </a>
@@ -38,7 +38,7 @@
     {if !$configuration.is_catalog}
       <a class="{$componentName}__link col-md-6 col-lg-4" id="history-link" href="{$urls.pages.history}">
         <span class="link-item">
-          <i class="material-icons">&#xE916;</i>
+          <i class="material-icons" aria-hidden="true">&#xE916;</i>
           {l s='Order history and details' d='Shop.Theme.Customeraccount'}
         </span>
       </a>
@@ -47,7 +47,7 @@
     {if !$configuration.is_catalog}
       <a class="{$componentName}__link col-md-6 col-lg-4" id="order-slips-link" href="{$urls.pages.order_slip}">
         <span class="link-item">
-          <i class="material-icons">&#xE8B0;</i>
+          <i class="material-icons" aria-hidden="true">&#xE8B0;</i>
           {l s='Credit slips' d='Shop.Theme.Customeraccount'}
         </span>
       </a>
@@ -56,7 +56,7 @@
     {if $configuration.voucher_enabled && !$configuration.is_catalog}
       <a class="{$componentName}__link col-md-6 col-lg-4" id="discounts-link" href="{$urls.pages.discount}">
         <span class="link-item">
-          <i class="material-icons">&#xE54E;</i>
+          <i class="material-icons" aria-hidden="true">&#xE54E;</i>
           {l s='Vouchers' d='Shop.Theme.Customeraccount'}
         </span>
       </a>
@@ -65,7 +65,7 @@
     {if $configuration.return_enabled && !$configuration.is_catalog}
       <a class="{$componentName}__link col-md-6 col-lg-4" id="returns-link" href="{$urls.pages.order_follow}">
         <span class="link-item">
-          <i class="material-icons">&#xE860;</i>
+          <i class="material-icons" aria-hidden="true">&#xE860;</i>
           {l s='Merchandise returns' d='Shop.Theme.Customeraccount'}
         </span>
       </a>
@@ -77,7 +77,7 @@
   </div>
 
   <a class="{$componentName}__logout d-md-none" href="{$urls.actions.logout}">
-    <i class="material-icons me-2">exit_to_app</i>
+    <i class="material-icons me-2" aria-hidden="true">exit_to_app</i>
     {l s='Sign out' d='Shop.Theme.Actions'}
   </a>
 {/block}

--- a/templates/customer/order-slip.tpl
+++ b/templates/customer/order-slip.tpl
@@ -29,7 +29,7 @@
               <td scope="row">{$slip.credit_slip_number}</td>
               <td>{$slip.credit_slip_date}</td>
               <td class="text-sm-center">
-                <a href="{$slip.url}"><i class="material-icons">&#xE415;</i></a>
+                <a href="{$slip.url}"><i class="material-icons" aria-hidden="true">&#xE415;</i></a>
               </td>
             </tr>
           {/foreach}

--- a/templates/customer/page.tpl
+++ b/templates/customer/page.tpl
@@ -19,7 +19,7 @@
         {/block}
         {block name='account_link'}
           <a class="btn btn-unstyle d-md-none account-menu__back" href="{$urls.pages.my_account}">
-            <i class="material-icons">&#xE5CB;</i> {l s='Back to your account' d='Shop.Theme.Customeraccount'}
+            <i class="material-icons" aria-hidden="true">&#xE5CB;</i> {l s='Back to your account' d='Shop.Theme.Customeraccount'}
           </a>
         {/block}
       {/block}

--- a/templates/customer/password-email.tpl
+++ b/templates/customer/password-email.tpl
@@ -27,7 +27,7 @@
     <section class="form-fields">
       <div class="mb-3">
         <label class="form-label required">{l s='Email address' d='Shop.Forms.Labels'}</label>
-        <input type="email" name="email" id="email" value="{if isset($smarty.post.email)}{$smarty.post.email|stripslashes}{/if}" class="form-control" required>
+        <input type="email" name="email" id="email" value="{if isset($smarty.post.email)}{stripslashes($smarty.post.email)}{/if}" class="form-control" required>
       </div>
       <button id="send-reset-link" class="form-control-submit btn btn-primary" name="submit" type="submit">
         {l s='Send reset link' d='Shop.Theme.Actions'}

--- a/templates/customer/password-email.tpl
+++ b/templates/customer/password-email.tpl
@@ -39,7 +39,7 @@
 {block name='page_footer'}
   <hr>
   <a id="back-to-login" href="{$urls.pages.my_account}" class="btn btn-unstyle btn-with-icon">
-    <i class="material-icons rtl-flip">&#xE5CB;</i>
+    <i class="material-icons rtl-flip" aria-hidden="true">&#xE5CB;</i>
     <span>{l s='Back to login' d='Shop.Theme.Actions'}</span>
   </a>
 {/block}

--- a/templates/customer/password-infos.tpl
+++ b/templates/customer/password-infos.tpl
@@ -25,7 +25,7 @@
 {block name='page_footer'}
   <hr>
   <a id="back-to-login" href="{$urls.pages.authentication}" class="btn btn-unstyle btn-with-icon">
-    <i class="material-icons rtl-flip">&#xE5CB;</i>
+    <i class="material-icons rtl-flip" aria-hidden="true">&#xE5CB;</i>
     <span>{l s='Back to login' d='Shop.Theme.Actions'}</span>
   </a>
 {/block}

--- a/templates/customer/password-new.tpl
+++ b/templates/customer/password-new.tpl
@@ -26,7 +26,7 @@
         {l
           s='Email address: %email%'
           d='Shop.Theme.Customeraccount'
-          sprintf=['%email%' => $customer_email|stripslashes]
+          sprintf=['%email%' => stripslashes($customer_email)]
         }
       </div>
       <div class="mb-3">

--- a/templates/customer/password-new.tpl
+++ b/templates/customer/password-new.tpl
@@ -32,14 +32,14 @@
       <div class="mb-3">
         <label class="form-label">{l s='New password' d='Shop.Forms.Labels'}</label>
         <div class="input-group password-field js-parent-focus">
-            <input class="form-control js-child-focus js-visible-password" type="password" data-validate="isPasswd" name="passwd" value="">
-            <button
-              class="btn btn-primary"
-              type="button"
-              data-action="show-password"
-              data-text-show="{l s='Show' d='Shop.Theme.Actions'}"
-              data-text-hide="{l s='Hide' d='Shop.Theme.Actions'}"
-            >
+          <input class="form-control js-child-focus js-visible-password" type="password" data-validate="isPasswd" name="passwd" value="">
+          <button
+            class="btn btn-primary"
+            type="button"
+            data-action="show-password"
+            data-text-show="{l s='Show' d='Shop.Theme.Actions'}"
+            data-text-hide="{l s='Hide' d='Shop.Theme.Actions'}"
+          >
             <i class="material-icons">visibility</i>
           </button>
         </div>
@@ -48,13 +48,13 @@
         <label class="form-label">{l s='Confirmation' d='Shop.Forms.Labels'}</label>
         <div class="input-group password-field js-parent-focus">
         <input class="form-control js-child-focus js-visible-password" type="password" data-validate="isPasswd" name="confirmation" value="">
-            <button
-              class="btn btn-primary"
-              type="button"
-              data-action="show-password"
-              data-text-show="{l s='Show' d='Shop.Theme.Actions'}"
-              data-text-hide="{l s='Hide' d='Shop.Theme.Actions'}"
-            >
+          <button
+            class="btn btn-primary"
+            type="button"
+            data-action="show-password"
+            data-text-show="{l s='Show' d='Shop.Theme.Actions'}"
+            data-text-hide="{l s='Hide' d='Shop.Theme.Actions'}"
+          >
             <i class="material-icons">visibility</i>
           </button>
         </div>
@@ -72,7 +72,7 @@
 {block name='page_footer'}
   <hr>
   <a id="back-to-login" href="{$urls.pages.authentication}" class="btn btn-unstyle btn-with-icon">
-    <i class="material-icons rtl-flip">&#xE5CB;</i>
+    <i class="material-icons rtl-flip" aria-hidden="true">&#xE5CB;</i>
     <span>{l s='Back to login' d='Shop.Theme.Actions'}</span>
   </a>
 {/block}

--- a/templates/customer/password-new.tpl
+++ b/templates/customer/password-new.tpl
@@ -37,8 +37,10 @@
             class="btn btn-primary"
             type="button"
             data-action="show-password"
-            data-text-show="{l s='Show' d='Shop.Theme.Actions'}"
-            data-text-hide="{l s='Hide' d='Shop.Theme.Actions'}"
+            data-text-show="{l s='Show Password' d='Shop.Theme.Actions'}"
+            data-text-hide="{l s='Hide Password' d='Shop.Theme.Actions'}"
+            aria-label="{l s='Show Password' d='Shop.Theme.Actions'}"
+            aria-expanded="false"
           >
             <i class="material-icons">visibility</i>
           </button>
@@ -52,8 +54,10 @@
             class="btn btn-primary"
             type="button"
             data-action="show-password"
-            data-text-show="{l s='Show' d='Shop.Theme.Actions'}"
-            data-text-hide="{l s='Hide' d='Shop.Theme.Actions'}"
+            data-text-show="{l s='Show Password' d='Shop.Theme.Actions'}"
+            data-text-hide="{l s='Hide Password' d='Shop.Theme.Actions'}"
+            aria-label="{l s='Show Password' d='Shop.Theme.Actions'}"
+            aria-expanded="false"
           >
             <i class="material-icons">visibility</i>
           </button>

--- a/templates/errors/not-found.tpl
+++ b/templates/errors/not-found.tpl
@@ -12,7 +12,7 @@
         <p>{l s='It can not be reached anymore. Can we still attract you into our shop?' d='Shop.Theme.Catalog'}</p>
         <a class="btn btn-outline-primary btn-with-icon mt-3" href="{$urls.pages.index}">
           {l s='Go shopping' d='Shop.Theme.Catalog'}
-          <i class="material-icons rtl-flip">&#xE315;</i>
+          <i class="material-icons rtl-flip" aria-hidden="true">&#xE315;</i>
         </a>
       {/if}
     {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fixed display issue when changing image on carousel in product page on a smaller screen best visibility is on 804px screen width. The issue was caused by bootstrap classes which was inserting display block instead of flex for a very short time which causes image to resize.
| Type?             | bug fix
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #504
| Sponsor company   | PrestaShopCorp
| How to test?      | Test slider on product page with different size images and different size screens. Slider must be stable and do not change the size. No content should be shifting.

Bootstrap automatically adds transition classes and one of the transition classes is `display block` while other classes are `display flex`. For a short time you can see image resize due to display differences
Previously:
As you can see image is to big for its size and these classes has 
```
.carousel-item.active, .carousel-item-next, .carousel-item-prev {
  display: block;
}
```
![image](https://github.com/GytisZum/hummingbird/assets/96050852/40cbd5fc-942e-48d2-acbe-c8b59e71448b)

After:
![image](https://github.com/GytisZum/hummingbird/assets/96050852/2b1d7973-8525-4443-8805-a197264e4685)
